### PR TITLE
Post checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "package-change-checker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -1,23 +1,22 @@
-const isHash = hash => hash && hash.length > 32 && /^[a-f0-9]+$/.test(hash);
-
 const parse = argv => {
   const [, , ...args] = argv;
   return args.reduce((acc, arg) => {
-    const installCmd = (arg.match(/--install-cmd=(.+)/) || [])[1];
-    if (installCmd) {
-      acc.installCmd = installCmd;
-    }
-
-    const quiet = arg.match(/--quiet/);
-    if (quiet) {
-      acc.quiet = true;
-    }
-
-    if (isHash(arg)) {
-      if (!acc.hashes) {
-        acc.hashes = [];
+    if (/^-/.test(arg)) {
+      const installCmd = (arg.match(/--install-cmd=(.+)/) || [])[1];
+      if (installCmd) {
+        acc.installCmd = installCmd;
       }
-      acc.hashes.push(arg);
+
+      const quiet = arg.match(/--quiet/);
+      if (quiet) {
+        acc.quiet = true;
+      }
+    } else {
+      // If arg does not start with hyphen, assume commitish
+      if (!acc.commitish) {
+        acc.commitish = [];
+      }
+      acc.commitish.push(arg);
     }
 
     return acc;

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -1,3 +1,5 @@
+const isHash = hash => hash && hash.length > 32 && /^[a-f0-9]+$/.test(hash);
+
 const parse = argv => {
   const [, , ...args] = argv;
   return args.reduce((acc, arg) => {
@@ -9,6 +11,13 @@ const parse = argv => {
     const quiet = arg.match(/--quiet/);
     if (quiet) {
       acc.quiet = true;
+    }
+
+    if (isHash(arg)) {
+      if (!acc.hashes) {
+        acc.hashes = [];
+      }
+      acc.hashes.push(arg);
     }
 
     return acc;

--- a/src/arg-parser.spec.js
+++ b/src/arg-parser.spec.js
@@ -38,28 +38,42 @@ describe('arg-parse.js', () => {
       });
     });
 
-    describe('when quiet arg is provided', () => {
-      it('should return quiet as true', () => {
-        const actual = parse(['node', 'file.js', '--quiet']);
+    describe('when hash arg is provided', () => {
+      it('should return hashes as array', () => {
+        const actual = parse([
+          'node',
+          'file.js',
+          'abcdef0123456789abcdef0123456789abcdef01',
+          'abcdef0123456789abcdef0123456789abcdef02',
+        ]);
 
         expect(actual).to.deep.equal({
-          quiet: true,
+          hashes: [
+            'abcdef0123456789abcdef0123456789abcdef01',
+            'abcdef0123456789abcdef0123456789abcdef02',
+          ],
         });
       });
     });
 
     describe('when multiple args are provided', () => {
-      it('should return two args', () => {
+      it('should return multiple args', () => {
         const actual = parse([
           'node',
           'file.js',
           '--quiet',
           '--install-cmd=yarn install && lerna bootstrap',
+          'abcdef0123456789abcdef0123456789abcdef01',
+          'abcdef0123456789abcdef0123456789abcdef02',
         ]);
 
         expect(actual).to.deep.equal({
           quiet: true,
           installCmd: 'yarn install && lerna bootstrap',
+          hashes: [
+            'abcdef0123456789abcdef0123456789abcdef01',
+            'abcdef0123456789abcdef0123456789abcdef02',
+          ],
         });
       });
     });

--- a/src/arg-parser.spec.js
+++ b/src/arg-parser.spec.js
@@ -38,8 +38,8 @@ describe('arg-parse.js', () => {
       });
     });
 
-    describe('when hash arg is provided', () => {
-      it('should return hashes as array', () => {
+    describe('when non-dash arg is provided', () => {
+      it('should return commit-ish as array', () => {
         const actual = parse([
           'node',
           'file.js',
@@ -48,7 +48,7 @@ describe('arg-parse.js', () => {
         ]);
 
         expect(actual).to.deep.equal({
-          hashes: [
+          commitish: [
             'abcdef0123456789abcdef0123456789abcdef01',
             'abcdef0123456789abcdef0123456789abcdef02',
           ],
@@ -70,7 +70,7 @@ describe('arg-parse.js', () => {
         expect(actual).to.deep.equal({
           quiet: true,
           installCmd: 'yarn install && lerna bootstrap',
-          hashes: [
+          commitish: [
             'abcdef0123456789abcdef0123456789abcdef01',
             'abcdef0123456789abcdef0123456789abcdef02',
           ],

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,9 +7,11 @@ const childProcess = require('child_process');
 const argParser = require('./arg-parser');
 const checker = require('./package-change-checker');
 
-const { installCmd = 'npm install', quiet = false } = argParser.parse(
-  process.argv
-);
+const {
+  installCmd = 'npm install',
+  quiet = false,
+  hashes = [],
+} = argParser.parse(process.argv);
 
 const log = msg => {
   if (!quiet) {
@@ -18,7 +20,7 @@ const log = msg => {
 };
 
 if (process.env.PACKAGE_CHANGE_CHECKER_DISABLED !== 'true') {
-  if (checker.hasChangedDependencies()) {
+  if (checker.hasChangedDependencies(hashes)) {
     log(`Dependencies have changed, running ${installCmd}...`);
     childProcess.execSync(installCmd, {
       stdio: 'inherit',

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ const checker = require('./package-change-checker');
 const {
   installCmd = 'npm install',
   quiet = false,
-  hashes = [],
+  commitish = [],
 } = argParser.parse(process.argv);
 
 const log = msg => {
@@ -20,7 +20,7 @@ const log = msg => {
 };
 
 if (process.env.PACKAGE_CHANGE_CHECKER_DISABLED !== 'true') {
-  if (checker.hasChangedDependencies(hashes)) {
+  if (checker.hasChangedDependencies(commitish)) {
     log(`Dependencies have changed, running ${installCmd}...`);
     childProcess.execSync(installCmd, {
       stdio: 'inherit',

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -16,8 +16,13 @@ describe('cli.js', () => {
     processEnv = process.env;
   });
 
-  const setup = (hasChangedDependenciesResult, installCmd, quiet) => {
-    sandbox.stub(argParser, 'parse').returns({ installCmd, quiet });
+  const setup = (
+    hasChangedDependenciesResult,
+    installCmd,
+    quiet,
+    hashes = []
+  ) => {
+    sandbox.stub(argParser, 'parse').returns({ installCmd, quiet, hashes });
     sandbox
       .stub(checker, 'hasChangedDependencies')
       .returns(hasChangedDependenciesResult);
@@ -39,9 +44,7 @@ describe('cli.js', () => {
     it('should default to run npm install', () => {
       setup(true);
 
-      expect(
-        checker.hasChangedDependencies
-      ).to.have.been.calledOnceWithExactly();
+      expect(checker.hasChangedDependencies).to.have.been.calledOnce();
       expect(console.log).to.have.been.calledOnceWithExactly(
         `Dependencies have changed, running npm install...`
       );
@@ -54,9 +57,7 @@ describe('cli.js', () => {
     it('should allow overriding of install cmd', () => {
       setup(true, 'yarn install && lerna bootstrap');
 
-      expect(
-        checker.hasChangedDependencies
-      ).to.have.been.calledOnceWithExactly();
+      expect(checker.hasChangedDependencies).to.have.been.calledOnce();
       expect(console.log).to.have.been.calledOnceWithExactly(
         `Dependencies have changed, running yarn install && lerna bootstrap...`
       );
@@ -79,9 +80,7 @@ describe('cli.js', () => {
     it('should not run npm install', () => {
       setup(false);
 
-      expect(
-        checker.hasChangedDependencies
-      ).to.have.been.calledOnceWithExactly();
+      expect(checker.hasChangedDependencies).to.have.been.calledOnce();
       expect(console.log).to.have.been.calledOnceWithExactly(
         'No dependency changes!'
       );

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -74,6 +74,20 @@ describe('cli.js', () => {
         expect(console.log).not.to.have.been.called();
       });
     });
+
+    describe('when non-dash args are used', () => {
+      it('should use commitish for the check', () => {
+        const commitish = [
+          'abcdef0123456789abcdef0123456789abcdef01',
+          'abcdef0123456789abcdef0123456789abcdef02',
+        ];
+        setup(true, undefined, undefined, commitish);
+
+        expect(
+          checker.hasChangedDependencies
+        ).to.have.been.calledOnceWithExactly(commitish);
+      });
+    });
   });
 
   describe('when dependencies have not changed', () => {

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -20,9 +20,9 @@ describe('cli.js', () => {
     hasChangedDependenciesResult,
     installCmd,
     quiet,
-    hashes = []
+    commitish = []
   ) => {
-    sandbox.stub(argParser, 'parse').returns({ installCmd, quiet, hashes });
+    sandbox.stub(argParser, 'parse').returns({ installCmd, quiet, commitish });
     sandbox
       .stub(checker, 'hasChangedDependencies')
       .returns(hasChangedDependenciesResult);

--- a/src/package-change-checker.js
+++ b/src/package-change-checker.js
@@ -3,11 +3,15 @@ const os = require('os');
 const git = require('./git');
 const loader = require('./loader');
 
-const commit1 = 'ORIG_HEAD';
-const commit2 = 'HEAD';
+let commit1 = 'ORIG_HEAD';
+let commit2 = 'HEAD';
 
-const hasChangedDependencies = () =>
-  git
+const hasChangedDependencies = (hashes = []) => {
+  if (hashes.length === 2) {
+    // assume post-checkout scenario with two hashes given as params from Git
+    [commit1, commit2] = hashes;
+  }
+  return git
     .getDiff(commit1, commit2, 'package.json **/package.json')
     .split(os.EOL)
     .filter(Boolean)
@@ -20,6 +24,7 @@ const hasChangedDependencies = () =>
       packages =>
         JSON.stringify(packages.before) !== JSON.stringify(packages.after)
     );
+};
 
 module.exports = {
   hasChangedDependencies,

--- a/src/package-change-checker.js
+++ b/src/package-change-checker.js
@@ -6,9 +6,9 @@ const loader = require('./loader');
 const defaultCommit1 = 'ORIG_HEAD';
 const defaultCommit2 = 'HEAD';
 
-const hasChangedDependencies = (hashes = []) => {
-  const commit1 = hashes[0] || defaultCommit1;
-  const commit2 = hashes[1] || defaultCommit2;
+const hasChangedDependencies = (commitish = []) => {
+  const commit1 = commitish[0] || defaultCommit1;
+  const commit2 = commitish[1] || defaultCommit2;
 
   return git
     .getDiff(commit1, commit2, 'package.json **/package.json')

--- a/src/package-change-checker.js
+++ b/src/package-change-checker.js
@@ -3,14 +3,13 @@ const os = require('os');
 const git = require('./git');
 const loader = require('./loader');
 
-let commit1 = 'ORIG_HEAD';
-let commit2 = 'HEAD';
+const defaultCommit1 = 'ORIG_HEAD';
+const defaultCommit2 = 'HEAD';
 
 const hasChangedDependencies = (hashes = []) => {
-  if (hashes.length === 2) {
-    // assume post-checkout scenario with two hashes given as params from Git
-    [commit1, commit2] = hashes;
-  }
+  const commit1 = hashes[0] || defaultCommit1;
+  const commit2 = hashes[1] || defaultCommit2;
+
   return git
     .getDiff(commit1, commit2, 'package.json **/package.json')
     .split(os.EOL)

--- a/src/package-change-checker.spec.js
+++ b/src/package-change-checker.spec.js
@@ -200,5 +200,24 @@ describe('package-change-checker.js', () => {
         expect(actual).to.be.true();
       });
     });
+
+    describe('with post-checkout hook providing two hashes', () => {
+      before(() => {
+        checker.hasChangedDependencies([
+          'abcdef0123456789abcdef0123456789abcdef01',
+          'abcdef0123456789abcdef0123456789abcdef02',
+        ]);
+      });
+
+      after(teardown);
+
+      it('should get the diff with the two provided hashes', () => {
+        expect(git.getDiff).to.have.been.calledOnceWithExactly(
+          'abcdef0123456789abcdef0123456789abcdef01',
+          'abcdef0123456789abcdef0123456789abcdef02',
+          'package.json **/package.json'
+        );
+      });
+    });
   });
 });

--- a/src/package-change-checker.spec.js
+++ b/src/package-change-checker.spec.js
@@ -201,7 +201,7 @@ describe('package-change-checker.js', () => {
       });
     });
 
-    describe('with post-checkout hook providing two hashes', () => {
+    describe('with post-checkout hook providing two commitish', () => {
       before(() => {
         checker.hasChangedDependencies([
           'abcdef0123456789abcdef0123456789abcdef01',
@@ -211,7 +211,7 @@ describe('package-change-checker.js', () => {
 
       after(teardown);
 
-      it('should get the diff with the two provided hashes', () => {
+      it('should get the diff with the two provided commitish', () => {
         expect(git.getDiff).to.have.been.calledOnceWithExactly(
           'abcdef0123456789abcdef0123456789abcdef01',
           'abcdef0123456789abcdef0123456789abcdef02',

--- a/src/package-change-checker.spec.js
+++ b/src/package-change-checker.spec.js
@@ -203,6 +203,12 @@ describe('package-change-checker.js', () => {
 
     describe('with post-checkout hook providing two commitish', () => {
       before(() => {
+        loaderStubsResults = {
+          'package.json': {
+            abcdef0123456789abcdef0123456789abcdef01: { somePackage: '1.2.3' },
+            abcdef0123456789abcdef0123456789abcdef02: { somePackage: '1.2.3' },
+          },
+        };
         checker.hasChangedDependencies([
           'abcdef0123456789abcdef0123456789abcdef01',
           'abcdef0123456789abcdef0123456789abcdef02',
@@ -216,6 +222,16 @@ describe('package-change-checker.js', () => {
           'abcdef0123456789abcdef0123456789abcdef01',
           'abcdef0123456789abcdef0123456789abcdef02',
           'package.json **/package.json'
+        );
+      });
+
+      it('should pass the provided commitish to loader', () => {
+        expect(loaderStubs['package.json']).to.have.been.calledTwice();
+        expect(loaderStubs['package.json']).to.have.been.calledWithExactly(
+          'abcdef0123456789abcdef0123456789abcdef01'
+        );
+        expect(loaderStubs['package.json']).to.have.been.calledWithExactly(
+          'abcdef0123456789abcdef0123456789abcdef02'
         );
       });
     });


### PR DESCRIPTION
We are using `package-change-checker` with [Husky](https://www.npmjs.com/package/husky) and it has been great. Now though, we believe we've hit a bug.

Our `.huskyrc` initially looked like this:
```
{
  "hooks": {
    "pre-commit": "lint-staged",
    "post-merge": "package-change-checker",
    "post-rewrite": "package-change-checker",
    "post-checkout": "package-change-checker"
  }
}
```
What we want to achieve is to run `npm install` whenever `package.json` changes after a `merge`, `rebase` or `checkout` operation.

The problem is that `package-change-checker` currently *always* compares `ORIG_HEAD` with `HEAD`. According to [docs](https://git-scm.com/docs/gitrevisions) and [SO](https://stackoverflow.com/a/967611) `ORIG_HEAD` is only moved/updated whenever the git operation is considered "drastic", which according to my testing is only upon `merge` and `rebase`. 
The `checkout` operations is not considered "drastic" so `ORIG_HEAD` is not moved for `git checkout <branch>`. This leads to incorrect behaviour when checking our branches as `ORIG_HEAD` will *NOT*  point to the tip of the "previous branch" but rather to the ref that was last merged or rebased.

So to try and fix this I have amended our `.huskyrc` to the following:
```
{
  "hooks": {
    "pre-commit": "lint-staged",
    "post-merge": "package-change-checker $HUSKY_GIT_PARAMS",
    "post-rewrite": "package-change-checker $HUSKY_GIT_PARAMS",
    "post-checkout": "package-change-checker $HUSKY_GIT_PARAMS"
  }
}
```
passing `$HUSKY_GIT_PARAMS` to `package-change-checker`. Since Git passes arguments to `post-checkout` hooks that contain information about the "previous HEAD" and "new HEAD" we can use that instead of `ORIG_HEAD` and `HEAD` when that info is available. 

This makes `git checkout` behave correctly when used as shown above.

Feedback appreciated as my solution feels a bit crude. It basically just sniffs for two hashes passed as arguments to `package-change-checker` and uses those instead when they are available. From what I can tell, currently the only Git hook that sends two hashes as parameters is `post-checkout`. Also the solution is a bit Husky-esque, meaning it kind of ties in to how Husky handles Git parameters to Git hooks. But I don't see how I can make this PR more generic. Any thoughts?