### PR TITLE
Validate passed commitish and fall back to default when invalid.

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -6,6 +6,15 @@ const run = cmd =>
     .toString()
     .trim();
 
+const isValidCommitish = commitish => {
+  try {
+    const type = run(`git cat-file -t ${commitish}`);
+    return type === 'commit' || type === 'tag';
+  } catch (e) {
+    return false;
+  }
+};
+
 const getDiff = (commit1, commit2, filter) =>
   run(
     `git diff-tree -r --name-only --no-commit-id ${commit1} ${commit2} ${filter}`
@@ -22,4 +31,5 @@ const getFileContent = (commit, path) => {
 module.exports = {
   getDiff,
   getFileContent,
+  isValidCommitish,
 };

--- a/src/git.spec.js
+++ b/src/git.spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 const childProcess = require('child_process');
 
-const { getDiff, getFileContent } = require('./git');
+const { getDiff, getFileContent, isValidCommitish } = require('./git');
 
 describe('git.js', () => {
   let execResult;
@@ -70,6 +70,40 @@ describe('git.js', () => {
       const actual = getFileContent('the-commit-hash', 'file/path.js');
 
       expect(actual).to.equal('{}');
+    });
+  });
+
+  describe('isValidCommitish', () => {
+    it('should return true for commits', () => {
+      execResult = () => Buffer.from('commit');
+
+      const actual = isValidCommitish('the-commit-hash');
+
+      expect(actual).to.be.true();
+    });
+
+    it('should return true for tags', () => {
+      execResult = () => Buffer.from('tag');
+
+      const actual = isValidCommitish('the-commit-hash');
+
+      expect(actual).to.be.true();
+    });
+
+    it('should return false for types other than commits and tags', () => {
+      execResult = () => Buffer.from('blob');
+
+      const actual = isValidCommitish('the-commit-hash');
+
+      expect(actual).to.be.false();
+    });
+
+    it('should return false for invalid references', () => {
+      execResult = () => Buffer.from('rebase');
+
+      const actual = isValidCommitish('the-commit-hash');
+
+      expect(actual).to.be.false();
     });
   });
 });

--- a/src/package-change-checker.js
+++ b/src/package-change-checker.js
@@ -7,8 +7,16 @@ const defaultCommit1 = 'ORIG_HEAD';
 const defaultCommit2 = 'HEAD';
 
 const hasChangedDependencies = (commitish = []) => {
-  const commit1 = commitish[0] || defaultCommit1;
-  const commit2 = commitish[1] || defaultCommit2;
+  let commit1 = defaultCommit1;
+  let commit2 = defaultCommit2;
+  if (commitish.length === 2) {
+    if (
+      git.isValidCommitish(commitish[0]) &&
+      git.isValidCommitish(commitish[1])
+    ) {
+      [commit1, commit2] = commitish;
+    }
+  }
 
   return git
     .getDiff(commit1, commit2, 'package.json **/package.json')


### PR DESCRIPTION
@lhaggar We hit a bug caused by #1 when used for `post-rewrite` during a rebase. [According to docs](https://github.com/git/git/blob/master/Documentation/githooks.txt#L427) the first argument passed to `post-rewrite` is the command used to invoke it. Do after a rebase `package-change-checker` would receive one argument only, `rebase`, and crash. So we have to validate any passed arguments to make sure that they are a commitish. If they are not valid we fall back to using `HEAD` and `ORIG_HEAD` as was always done before #1.