### PR TITLE
post-checkout hook always provides a third argument.

### DIFF
--- a/src/package-change-checker.js
+++ b/src/package-change-checker.js
@@ -9,7 +9,7 @@ const defaultCommit2 = 'HEAD';
 const hasChangedDependencies = (commitish = []) => {
   let commit1 = defaultCommit1;
   let commit2 = defaultCommit2;
-  if (commitish.length === 2) {
+  if (commitish.length >= 2) {
     if (
       git.isValidCommitish(commitish[0]) &&
       git.isValidCommitish(commitish[1])

--- a/src/package-change-checker.spec.js
+++ b/src/package-change-checker.spec.js
@@ -213,6 +213,7 @@ describe('package-change-checker.js', () => {
         checker.hasChangedDependencies([
           'abcdef0123456789abcdef0123456789abcdef01',
           'abcdef0123456789abcdef0123456789abcdef02',
+          '1',
         ]);
       });
 
@@ -251,7 +252,7 @@ describe('package-change-checker.js', () => {
       });
 
       it('should use default commitish when two invalid commitish are provided', () => {
-        checker.hasChangedDependencies(['', '']);
+        checker.hasChangedDependencies(['', '', '1']);
         expect(git.isValidCommitish).to.have.been.calledOnceWithExactly('');
         expect(git.getDiff).to.have.been.calledOnceWithExactly(
           'ORIG_HEAD',
@@ -264,6 +265,7 @@ describe('package-change-checker.js', () => {
         checker.hasChangedDependencies([
           'abcdef0123456789abcdef0123456789abcdef01',
           '',
+          '1'
         ]);
         expect(git.isValidCommitish).to.have.been.calledTwice();
         expect(git.isValidCommitish).to.have.been.calledWithExactly(


### PR DESCRIPTION
Hi again @lhaggar 👋 

We're back with another PR.

We noticed that #2 did wonders for the rebase case but made the checkout case worse. We've used this patch ourselves for a week now and it fixes the bug properly (I hope 😄)

The bug is caused by `post-checkout` always passing three argument. From the git docs:
>The hook is given three parameters: the ref of the previous HEAD,
the ref of the new HEAD (which may or may not have changed), and a flag
indicating whether the checkout was a branch checkout (changing branches,
flag=1) or a file checkout (retrieving a file from the index, flag=0).

Right now the commitish check looks for exactly two arguments only, which makes `post-checkout` revert to the behaviour of the original package-change-checker before #1. This patch addresses this.